### PR TITLE
HUB-36 setup tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dev-dependencies = [
     "cz-conventional-gitmoji>=0.7.0",
     "pytest>=8.4.2",
     "httpx>=0.27.0",
+    "pytest-spec>=6.0.0",
 ]
 
 [tool.ruff]
@@ -143,6 +144,10 @@ changelog_start_rev = "v0.1.0"
 # Customize commit message format
 message_template = "{% raw %}{{change_type}}{% if scope %}({{scope}}){% endif %}: {{message}}{% endraw %}"
 
+[tool.pytest.ini_options]
+addopts = "--spec"
+testpaths = ["tests"]
+
 [tool.pyright]
 # Target the same Python version as the project
 pythonVersion = "3.13"
@@ -151,8 +156,8 @@ pythonVersion = "3.13"
 venvPath = "."
 venv = ".venv"
 
-# Include only source code
-include = ["src"]
+# Include source code and tests
+include = ["src", "tests"]
 
 # Exclude everything we don't want to type check
 exclude = [

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,22 +1,10 @@
-from fastapi.testclient import TestClient
-import pytest
-
-from src.main import app
-
-
 class TestNested:
-    class TestRoot:
-        @pytest.fixture(name="client")
-        def client_fixture(self):
-            yield TestClient(app)
+    class TestBuiltInFunction:
+        """THis is a dummy test, we don't usually test built-ins"""
 
-        def test_returns_200(self, client):
-            response = client.get("/")
-            assert response.status_code == 200
-
-        def test_includes_git_sha_in_response(self, client):
-            response = client.get("/")
-            assert "git_sha" in response.json()
+        def test_len(self):
+            """Does this override test descriptions?"""
+            assert len([1, 2, 3]) == 3
 
     class TestDummy:
         def test_addition(self):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,26 @@
+from fastapi.testclient import TestClient
+import pytest
+
+from src.main import app
+
+
+class TestNested:
+    class TestRoot:
+        @pytest.fixture(name="client")
+        def client_fixture(self):
+            yield TestClient(app)
+
+        def test_returns_200(self, client):
+            response = client.get("/")
+            assert response.status_code == 200
+
+        def test_includes_git_sha_in_response(self, client):
+            response = client.get("/")
+            assert "git_sha" in response.json()
+
+    class TestDummy:
+        def test_addition(self):
+            assert 1 + 2 == 3
+
+        def test_subtraction(self):
+            assert 3 - 1 == 2

--- a/uv.lock
+++ b/uv.lock
@@ -414,6 +414,7 @@ dev = [
     { name = "pre-commit" },
     { name = "pyright" },
     { name = "pytest" },
+    { name = "pytest-spec" },
     { name = "ruff" },
 ]
 
@@ -435,6 +436,7 @@ dev = [
     { name = "pre-commit", specifier = ">=4.3.0" },
     { name = "pyright", specifier = ">=1.1.406" },
     { name = "pytest", specifier = ">=8.4.2" },
+    { name = "pytest-spec", specifier = ">=6.0.0" },
     { name = "ruff", specifier = ">=0.13.3" },
 ]
 
@@ -767,7 +769,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -776,9 +778,18 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-spec"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/cf/c36d3e2bad61018e426090d68b0a7ca9c7e386ab95d901147b4eab9904ae/pytest_spec-6.0.0.tar.gz", hash = "sha256:2db490edb4f277b84fd18913fe74be7dbadd47aa24390c0b6044760feaf02f55", size = 1193809, upload-time = "2026-02-22T21:27:55.387Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/a3/61a43002eeeb8bd00db58e3a4c0e5db78732e51f794183c0d14138e00ab9/pytest_spec-6.0.0-py3-none-any.whl", hash = "sha256:af4abcfd678009d9ef46a8af9261a89c84b20d177e3e40a68d038ce0963428b2", size = 15292, upload-time = "2026-02-22T21:27:54.113Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Setup Pytest with [`pytest-spec`](https://github.com/pchomik/pytest-spec) as the output format.
- Add sample nested tests to serve as basis.

Resolves infuseth-ink/hub#36