### PR TITLE
HUB-36: Significant Other VSCode extension compat

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,6 +148,10 @@ message_template = "{% raw %}{{change_type}}{% if scope %}({{scope}}){% endif %}
 addopts = "--spec"
 testpaths = ["tests"]
 
+# https://marketplace.visualstudio.com/items?itemName=jasonrudolph.significant-other
+python_files = ["*_test.py"] # Significant Other compatibility
+python_classes = ["*Test"] # mirrors the filename suffix convention
+
 [tool.pyright]
 # Target the same Python version as the project
 pythonVersion = "3.13"

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -1,12 +1,11 @@
-class TestNested:
-    class TestBuiltInFunction:
+class NestedTest:
+    class BuiltInFunctionTest:
         """THis is a dummy test, we don't usually test built-ins"""
 
         def test_len(self):
-            """Does this override test descriptions?"""
             assert len([1, 2, 3]) == 3
 
-    class TestDummy:
+    class DummyTest:
         def test_addition(self):
             assert 1 + 2 == 3
 


### PR DESCRIPTION
Follows up #7 and resolves infuseth-ink/hub#36.  Makes it compatible with [Significant Other](https://marketplace.visualstudio.com/items?itemName=jasonrudolph.significant-other).