### PR TITLE
G-27: bootstrap Wireup DI migration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "psycopg[binary,pool]==3.3.3",
     "pydantic-settings>=2.0.0",
     "scalar-fastapi>=1.8.2",
+    "wireup>=2.10.0",
 ]
 
 [tool.uv]

--- a/src/config.py
+++ b/src/config.py
@@ -19,7 +19,7 @@ class Settings(BaseSettings):
     """
 
     database_url: str
-    """PostgreSQL connection string, e.g. postgresql+asyncpg://user:password@localhost:5432/dbname"""
+    """PostgreSQL connection string, e.g. postgresql+psycopg://user:password@localhost:5432/dbname"""
 
     debug: bool = False
     """Enable debug mode with SQL query logging (default: False)"""

--- a/src/config.py
+++ b/src/config.py
@@ -36,7 +36,7 @@ class Settings(BaseSettings):
 
 @injectable
 def settings_factory() -> Settings:
-    """Create the Settings instance from environment variables, necessary since Wireup things the
+    """Create the Settings instance from environment variables, necessary since Wireup thinks the
     settings class needs database_url, debug, etc. as injectables, but we want to load those from
     environment variables using Pydantic's BaseSettings."""
     return Settings()  # type: ignore[call-arg]

--- a/src/config.py
+++ b/src/config.py
@@ -1,8 +1,7 @@
 """Application configuration using Pydantic Settings."""
 
-from functools import lru_cache
-
 from pydantic_settings import BaseSettings, SettingsConfigDict
+from wireup import injectable
 
 
 class Settings(BaseSettings):
@@ -20,21 +19,22 @@ class Settings(BaseSettings):
     """
 
     database_url: str
+    """PostgreSQL connection string, e.g. postgresql+asyncpg://user:password@localhost:5432/dbname"""
+
     debug: bool = False
+    """Enable debug mode with SQL query logging (default: False)"""
+
     git_sha: str | None = None
+    """Current Git SHA of the deployed code.  Always available in remote environments,
+    but would almost always be None in local development unless explicitly set.
+
+    Helps determine if latest code is deployed and can rule out old code still being served.
+    """
 
     model_config = SettingsConfigDict(env_file=".env")
 
 
-@lru_cache
-def get_settings() -> Settings:
-    """Get cached settings instance.
-
-    Returns:
-        Settings: Application settings
-
-    Note:
-        Uses lru_cache to create settings only once during app lifetime.
-        This is FastAPI's recommended pattern for settings management.
-    """
+@injectable
+def settings_factory() -> Settings:
+    """Create the Settings instance from environment variables."""
     return Settings()  # type: ignore[call-arg]

--- a/src/config.py
+++ b/src/config.py
@@ -36,5 +36,7 @@ class Settings(BaseSettings):
 
 @injectable
 def settings_factory() -> Settings:
-    """Create the Settings instance from environment variables."""
+    """Create the Settings instance from environment variables, necessary since Wireup things the
+    settings class needs database_url, debug, etc. as injectables, but we want to load those from
+    environment variables using Pydantic's BaseSettings."""
     return Settings()  # type: ignore[call-arg]

--- a/src/database.py
+++ b/src/database.py
@@ -5,7 +5,7 @@ from functools import lru_cache
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 
-from .config import get_settings
+from .config import Settings
 
 
 @lru_cache
@@ -18,7 +18,7 @@ def get_engine():
     Note:
         Uses lru_cache to create engine only once during app lifetime.
     """
-    settings = get_settings()
+    settings = Settings()  # type: ignore[call-arg]
 
     # SQLAlchemy defaults to psycopg2, but we have psycopg3 installed
     # Explicitly specify the driver for psycopg3

--- a/src/greetings/schemas.py
+++ b/src/greetings/schemas.py
@@ -3,7 +3,9 @@
 from datetime import datetime
 from typing import Annotated
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import Field, model_validator
+
+from src.schemas import AppBaseSchema
 
 # Single source of truth for field constraints shared across DTOs
 GreetingField = Annotated[str, Field(min_length=1, max_length=500)]
@@ -11,13 +13,13 @@ NameField = Annotated[str, Field(min_length=1, max_length=100)]
 EmojiField = Annotated[str, Field(min_length=1, max_length=10)]
 
 
-class GreetingCreate(BaseModel):
+class GreetingCreate(AppBaseSchema):
     greeting: GreetingField
     name: NameField
     emoji: EmojiField | None = None
 
 
-class GreetingUpdate(BaseModel):
+class GreetingUpdate(AppBaseSchema):
     # Nullable PATCH pattern — ref: https://apipark.com/techblog/en/fastapi-elegant-solutions-for-none-null-handling/
     #
     # The distinction between "unset" and "null" is preserved by using
@@ -46,9 +48,7 @@ class GreetingUpdate(BaseModel):
         return values
 
 
-class GreetingPublic(BaseModel):
-    model_config = ConfigDict(from_attributes=True)
-
+class GreetingPublic(AppBaseSchema):
     id: int
     greeting: str
     name: str
@@ -57,7 +57,7 @@ class GreetingPublic(BaseModel):
     updated_at: datetime
 
 
-class GreetingListPublic(BaseModel):
+class GreetingListPublic(AppBaseSchema):
     items: list[GreetingPublic]
     total: int
     page: int

--- a/src/health_check/schemas.py
+++ b/src/health_check/schemas.py
@@ -1,0 +1,20 @@
+from src.schemas import AppBaseSchema
+
+
+class HealthCheckResponse(AppBaseSchema):
+    """
+    Health check response schema.
+    """
+
+    http: bool
+    """HTTP server is running."""
+
+    database: bool
+    """Database connection is healthy."""
+
+    git_sha: str | None = None
+    """Current Git SHA of the deployed code.  Always available in remote environments,
+    but would almost always be None in local development unless explicitly set.
+
+    Helps determine if latest code is deployed and can rule out old code still being served.
+    """

--- a/src/health_check/service.py
+++ b/src/health_check/service.py
@@ -1,0 +1,16 @@
+from wireup import injectable
+
+from src.config import Settings
+
+from .schemas import HealthCheckResponse
+
+
+@injectable
+class HealthCheckService:
+    def __init__(self, settings: Settings):
+        self.settings = settings
+
+    async def check(self):
+        return HealthCheckResponse(
+            database=True, http=True, git_sha=self.settings.git_sha
+        )

--- a/src/main.py
+++ b/src/main.py
@@ -68,5 +68,7 @@ async def root(health_check_service: Injected[HealthCheckService]):
     return await health_check_service.check()
 
 
-container = wireup.create_async_container(injectables=[])
+container = wireup.create_async_container(
+    injectables=[settings_factory, HealthCheckService]
+)
 wireup.integration.fastapi.setup(container, app)

--- a/src/main.py
+++ b/src/main.py
@@ -6,6 +6,7 @@ import wireup
 from wireup import Injected
 import wireup.integration.fastapi
 
+from src.health_check.schemas import HealthCheckResponse
 from src.health_check.service import HealthCheckService
 
 from .config import settings_factory
@@ -64,7 +65,9 @@ async def scalar_docs() -> HTMLResponse:
 
 
 @app.get("/")
-async def root(health_check_service: Injected[HealthCheckService]):
+async def root(
+    health_check_service: Injected[HealthCheckService],
+) -> HealthCheckResponse:
     return await health_check_service.check()
 
 

--- a/src/main.py
+++ b/src/main.py
@@ -2,6 +2,8 @@ from fastapi import Depends, FastAPI
 from fastapi.openapi.utils import get_openapi
 from fastapi.responses import HTMLResponse
 from scalar_fastapi import get_scalar_api_reference
+import wireup
+import wireup.integration.fastapi
 
 from .config import Settings, get_settings
 from .greetings.router import router as greetings_router
@@ -61,3 +63,7 @@ async def scalar_docs() -> HTMLResponse:
 @app.get("/")
 async def root(settings: Settings = Depends(get_settings)):
     return {"message": "Hello World", "git_sha": settings.git_sha}
+
+
+container = wireup.create_async_container(injectables=[])
+wireup.integration.fastapi.setup(container, app)

--- a/src/main.py
+++ b/src/main.py
@@ -1,11 +1,14 @@
-from fastapi import Depends, FastAPI
+from fastapi import FastAPI
 from fastapi.openapi.utils import get_openapi
 from fastapi.responses import HTMLResponse
 from scalar_fastapi import get_scalar_api_reference
 import wireup
+from wireup import Injected
 import wireup.integration.fastapi
 
-from .config import Settings, get_settings
+from src.health_check.service import HealthCheckService
+
+from .config import settings_factory
 from .greetings.router import router as greetings_router
 
 app = FastAPI(docs_url=None, redoc_url=None)
@@ -61,8 +64,8 @@ async def scalar_docs() -> HTMLResponse:
 
 
 @app.get("/")
-async def root(settings: Settings = Depends(get_settings)):
-    return {"message": "Hello World", "git_sha": settings.git_sha}
+async def root(health_check_service: Injected[HealthCheckService]):
+    return await health_check_service.check()
 
 
 container = wireup.create_async_container(injectables=[])

--- a/src/main.py
+++ b/src/main.py
@@ -68,6 +68,9 @@ async def scalar_docs() -> HTMLResponse:
 async def root(
     health_check_service: Injected[HealthCheckService],
 ) -> HealthCheckResponse:
+    """Health check endpoint that returns hardcoded "OK" status for HTTP and DB for now, along
+    with the Git SHA from settings for deployment tracking.
+    """
     return await health_check_service.check()
 
 

--- a/src/schemas.py
+++ b/src/schemas.py
@@ -1,0 +1,9 @@
+from pydantic import BaseModel, ConfigDict
+
+
+class AppBaseSchema(BaseModel):
+    """
+    Base model for all application schemas.
+    """
+
+    model_config = ConfigDict(from_attributes=True, use_attribute_docstrings=True)

--- a/uv.lock
+++ b/uv.lock
@@ -409,6 +409,7 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "scalar-fastapi" },
     { name = "sqlalchemy" },
+    { name = "wireup" },
 ]
 
 [package.dev-dependencies]
@@ -432,6 +433,7 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.0.0" },
     { name = "scalar-fastapi", specifier = ">=1.8.2" },
     { name = "sqlalchemy", specifier = ">=2.0.0" },
+    { name = "wireup", specifier = ">=2.10.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -1141,6 +1143,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
     { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
     { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]
+
+[[package]]
+name = "wireup"
+version = "2.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/a0/2b4c04b030ba22bb5b75ffc2b8d077b7cb5635397160070551df2d05d3cf/wireup-2.10.0.tar.gz", hash = "sha256:0913de3002872b8e68848d9ea7ab7bc45c2c4bf5a63c6fc35e181df286082a2e", size = 791102, upload-time = "2026-04-29T21:21:18.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/d4/83d79633b96f9784a1f0c1ffa728aaf05e9760dc781158c1f00292600081/wireup-2.10.0-py3-none-any.whl", hash = "sha256:252368a254010986ee89919087f9610c44f8fdf4753961bbb60d242dadbdfe5f", size = 58085, upload-time = "2026-04-29T21:21:19.977Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Migrate to Wireup using [this guide](https://maldoinc.github.io/wireup/latest/migrate_to_wireup/fastapi_depends). Resolves #27.

Endpoints still work:

```sh
curl 'http://localhost:8000/greetings?sort=asc&page=1&limit=20' | jq
```

```json5
{
  "items": [
    {
      "id": 3,
      "greeting": "Ola",
      "name": "Miamiga",
      "emoji": null,
      "created_at": "2026-05-02T08:06:51.014038Z",
      "updated_at": "2026-05-02T08:06:51.014038Z"
    },
    {
      "id": 1,
      "greeting": "Bonjour",
      "name": "Mike",
      "emoji": null,
      "created_at": "2026-05-01T08:06:33.316610Z",
      "updated_at": "2026-05-02T08:02:26.528910Z"
    }
  ],
  "total": 2,
  "page": 1,
  "limit": 20
}
```